### PR TITLE
set license version in cabal files

### DIFF
--- a/HaXml-1.25.5/HaXml.cabal
+++ b/HaXml-1.25.5/HaXml.cabal
@@ -2,7 +2,7 @@ cabal-version:  >= 1.8
 name:           HaXml
 version:        1.25.6
 
-license:        LGPL
+license:        LGPL-2.1
 license-files:  COPYRIGHT, LICENCE-GPL, LICENCE-LGPL
 author:         Malcolm Wallace <Malcolm.Wallace@me.com>
 maintainer:     author

--- a/cpphs-1.20.9/cpphs.cabal
+++ b/cpphs-1.20.9/cpphs.cabal
@@ -1,7 +1,7 @@
 Name: cpphs
 Version: 1.20.9.1
 Copyright: 2004-2017, Malcolm Wallace
-License: LGPL
+License: LGPL-2.1
 License-File: LICENCE-LGPL
 Cabal-Version: >= 1.8
 Author: Malcolm Wallace <Malcolm.Wallace@me.com>

--- a/hscolour-1.24.4/hscolour.cabal
+++ b/hscolour-1.24.4/hscolour.cabal
@@ -4,7 +4,7 @@ Copyright: 2003-2017 Malcolm Wallace; 2006 Bjorn Bringert
 Maintainer: Malcolm Wallace
 Author: Malcolm Wallace
 Homepage: http://code.haskell.org/~malcolm/hscolour/
-License: LGPL
+License: LGPL-2.1
 License-file: LICENCE-LGPL
 Synopsis: Colourise Haskell code.
 Description:

--- a/polyparse-1.12/polyparse.cabal
+++ b/polyparse-1.12/polyparse.cabal
@@ -1,7 +1,7 @@
 name:           polyparse
 version:        1.13
 x-revision:     2
-license:        LGPL
+license:        LGPL-2.1
 license-files:   COPYRIGHT, LICENCE-LGPL, LICENCE-commercial
 copyright:      (c) 2006-2016 Malcolm Wallace
 author:         Malcolm Wallace <Malcolm.Wallace@me.com>


### PR DESCRIPTION
I saw that you were preparing a release for HaXML and I was wondering if this could be included in that.

Currently none of these packages specify the LGPL version that they are licensed under, which annoys tooling that expects that, eg, [haskell.nix](https://github.com/input-output-hk/haskell.nix).

I've specified the version for all the packages in this repo, but I can just restrict it to HaXML if that's the only one you are interested in.